### PR TITLE
Fix: PHP Deprecated:  Using ${var} in strings is deprecated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
+        "php": ">=8.1",
         "nesbot/carbon": ">=1.29.0"
     },
     "require-dev": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,25 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
->
-    <testsuites>
-        <testsuite name="PHP-Hijri Test Suite">
-            <directory suffix="Test.php">./tests/</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-            <exclude>
-                <directory suffix=".php">src</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="PHP-Hijri Test Suite">
+      <directory suffix="Test.php">./tests/</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src</directory>
+    </exclude>
+  </source>
 </phpunit>

--- a/phpunit.xml.bak
+++ b/phpunit.xml.bak
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+>
+    <testsuites>
+        <testsuite name="PHP-Hijri Test Suite">
+            <directory suffix="Test.php">./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src</directory>
+            <exclude>
+                <directory suffix=".php">src</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Hijri.php
+++ b/src/Hijri.php
@@ -3,7 +3,12 @@
 namespace Pharaonic\Hijri;
 
 use Carbon\Carbon;
+use Carbon\Exceptions\InvalidFormatException;
+use Carbon\Month;
 use Carbon\Translator;
+use Carbon\WeekDay;
+use DateTimeInterface;
+use DateTimeZone;
 
 class Hijri extends Carbon
 {
@@ -147,9 +152,9 @@ class Hijri extends Carbon
      *
      * @return static
      */
-    public static function parse($time = null, $tz = null)
+    public static function parse(DateTimeInterface|WeekDay|Month|string|int|float|null $time = null, DateTimeZone|string|int|null $timezone = null): static
     {
-        return self::$HIJRI_INSTANCE->prepare(parent::parse($time, $tz));
+        return self::$HIJRI_INSTANCE->prepare(parent::parse($time, $timezone));
     }
 
     /**
@@ -160,7 +165,7 @@ class Hijri extends Carbon
      *
      * @return $this|string
      */
-    public function locale(string $locale = null, ...$fallbackLocales)
+    public function locale(?string $locale = null, string ...$fallbackLocales): static|string
     {
         if ($locale === null) {
             return $this->getTranslatorLocale();
@@ -203,7 +208,7 @@ class Hijri extends Carbon
      *
      * @return string
      */
-    public function getTranslatedDayName($context = null, $keySuffix = '', $defaultValue = null)
+    public function getTranslatedDayName(?string $context = null, string $keySuffix = '', ?string $defaultValue = null): string
     {
         return $this->getTranslatedFormByRegExp('weekdays', $keySuffix, $context, $this->CURRENT_DAY, $defaultValue ?: $this->englishDayOfWeek);
     }
@@ -237,7 +242,7 @@ class Hijri extends Carbon
      *
      * @return string
      */
-    public function getTranslatedMonthName($context = null, $keySuffix = '', $defaultValue = null)
+    public function getTranslatedMonthName(?string $context = null, string $keySuffix = '', ?string $defaultValue = null): string
     {
         return $this->getTranslatedFormByRegExp('months', $keySuffix, $context, $this->month - 1, $defaultValue ?: $this->englishMonth);
     }
@@ -249,7 +254,7 @@ class Hijri extends Carbon
      *
      * @return string
      */
-    public function format($format)
+    public function format(string $format): string
     {
         return str_replace([
             $this->englishDayOfWeek,

--- a/src/Hijri.php
+++ b/src/Hijri.php
@@ -211,7 +211,7 @@ class Hijri extends Carbon
     protected function getTranslatedFormByRegExp($baseKey, $keySuffix, $context, $subKey, $defaultValue)
     {
         $key = $baseKey . $keySuffix;
-        $standaloneKey = "${key}_standalone";
+        $standaloneKey = "{$key}_standalone";
         $baseTranslation = $this->getTranslationMessage($key);
 
         if ($baseTranslation instanceof Closure) {
@@ -220,7 +220,7 @@ class Hijri extends Carbon
 
         if (
             $this->getTranslationMessage("$standaloneKey.$subKey") &&
-            (!$context || ($regExp = $this->getTranslationMessage("${baseKey}_regexp")) && !preg_match($regExp, $context))
+            (!$context || ($regExp = $this->getTranslationMessage("{$baseKey}_regexp")) && !preg_match($regExp, $context))
         ) {
             $key = $standaloneKey;
         }


### PR DESCRIPTION
Fix PHP message: PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead